### PR TITLE
DEV: Rename plugin to discourse-upvotes part 1

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,14 +1,14 @@
 [main]
 host = https://www.transifex.com
 
-[discourse-question-answer.client-en-yml]
+[discourse-upvotes.client-en-yml]
 file_filter = config/locales/client.<lang>.yml
 minimum_perc = 0
 source_file = config/locales/client.en.yml
 source_lang = en
 type = YML
 
-[discourse-question-answer.server-en-yml]
+[discourse-upvotes.server-en-yml]
 file_filter = config/locales/server.<lang>.yml
 source_file = config/locales/server.en.yml
 source_lang = en

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-:warning: This plugin is still in active development and is not production ready.
+# Discourse Upvotes
 
-# Discourse Question & Answer
+![discourse upvotes](https://d11a6trkgmumsb.cloudfront.net/optimized/4X/f/e/5/fe50a4c07cc24ec0b10e64ec5d32154c7a140d9e_2_876x750.jpeg)
+
+Please refer to https://meta.discourse.org/t/227808 for more info!
 
 ## Contributions
 

--- a/assets/javascripts/discourse/initializers/extend-composer-actions.js
+++ b/assets/javascripts/discourse/initializers/extend-composer-actions.js
@@ -38,7 +38,7 @@ export default {
       });
 
       api.modifyClass("component:composer-actions", {
-        pluginId: "discourse-question-answer",
+        pluginId: "discourse-upvotes",
 
         toggleQASelected(options, model) {
           model.toggleProperty("createAsQA");
@@ -78,7 +78,7 @@ export default {
       });
 
       api.modifyClass("model:composer", {
-        pluginId: "discourse-question-answer",
+        pluginId: "discourse-upvotes",
 
         @observes("categoryId")
         categoryCreateAsQADefault() {

--- a/assets/javascripts/discourse/initializers/qa-edits.js
+++ b/assets/javascripts/discourse/initializers/qa-edits.js
@@ -2,7 +2,7 @@ import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 export const ORDER_BY_ACTIVITY_FILTER = "activity";
-const pluginId = "discourse-question-answer";
+const pluginId = "discourse-upvotes";
 
 function initPlugin(api) {
   api.removePostMenuButton("reply", (attrs) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "discourse-question-answer",
+  "name": "discourse-upvotes",
   "version": "0.1",
-  "repository": "https://github.com/discourse/discourse-question-answer",
+  "repository": "https://github.com/discourse/discourse-upvotes",
   "author": "Alan Tan",
   "license": "MIT",
   "devDependencies": {

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# name: discourse-question-answer
+# name: discourse-upvotes
 # about: Allows a topic to be created in the Q&A format
 # version: 0.0.1
 # authors: Alan Tan
-# url: https://github.com/discourse/discourse-question-answer
+# url: https://github.com/discourse/discourse-upvotes
 # transpile_js: true
 
 %i[common mobile].each do |type|


### PR DESCRIPTION
A functional name change. The "Q&A" name carries a lot of meaning which this plugin is not intended for. Part 1 is just plugin name change, part 2 will include filenames and symbols.

t/52356/146

Screenshot to prove it's functional:
<img width="794" alt="Screenshot 2022-09-20 at 5 20 01 PM" src="https://user-images.githubusercontent.com/1555215/191220016-4fd3b58d-c7e9-42a9-a3b0-bc54cb2918f1.png">
