### PR TITLE
DEV: Fix specs for personal_message_enabled_groups setting

### DIFF
--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -24,6 +24,7 @@ describe PostsController do
     end
 
     it "ignores create_as_qa param when trying to create private message" do
+      Group.refresh_automatic_groups!
       post "/posts.json", params: {
         raw: 'this is some raw',
         title: 'this is some title',


### PR DESCRIPTION
See https://github.com/discourse/discourse/pull/18437, we are removing any references to enable_personal_messages in core and using only personal_message_enabled_groups, which requires auto groups to be assigned in certain specs for them to keep working.