### PR TITLE
DEV: Drop support for upgrade Pavilion's discourse-question-answer plugin

### DIFF
--- a/db/migrate/20211020062413_create_question_answer_votes.rb
+++ b/db/migrate/20211020062413_create_question_answer_votes.rb
@@ -10,57 +10,7 @@ class CreateQuestionAnswerVotes < ActiveRecord::Migration[6.1]
 
     add_index :question_answer_votes, [:post_id, :user_id], unique: true
 
-    execute <<~SQL
-    INSERT INTO question_answer_votes (post_id, user_id, created_at)
-    SELECT
-      X.post_id AS post_id,
-      (X.value->>'user_id')::int AS user_id,
-      (X.value->>'created_at')::timestamp AS created_at
-    FROM (
-      SELECT
-        post_id,
-        jsonb_array_elements(value::jsonb) AS value
-      FROM post_custom_fields WHERE name = 'vote_history'
-    ) AS X
-    WHERE (X.value->>'action') != 'destroy'
-    ORDER BY (X.value->>'created_at')::timestamp DESC
-    ON CONFLICT DO NOTHING
-    SQL
-
-    execute <<~SQL
-    DELETE FROM question_answer_votes
-    USING (
-      SELECT
-        X.post_id AS post_id,
-        (X.value->>'user_id')::int AS user_id,
-        (X.value->>'created_at')::timestamp AS created_at
-      FROM (
-        SELECT
-          post_id,
-          jsonb_array_elements(value::jsonb) AS value
-        FROM post_custom_fields WHERE name = 'vote_history'
-      ) AS X
-      WHERE (X.value->>'action') = 'destroy'
-    ) AS Y
-    WHERE question_answer_votes.post_id = Y.post_id
-    AND question_answer_votes.user_id = Y.user_id
-    AND question_answer_votes.created_at < Y.created_at
-    SQL
-
     add_column :posts, :qa_vote_count, :integer, default: 0, null: true
-
-    execute <<~SQL
-    UPDATE posts p
-    SET qa_vote_count = X.count
-    FROM (
-      SELECT
-        post_id,
-        COUNT(*) AS count
-      FROM question_answer_votes
-      GROUP BY post_id
-    ) AS X
-    WHERE X.post_id = p.id
-    SQL
   end
 
   def down


### PR DESCRIPTION
We’ll be dropping support to convert the old plugin's data to this plugin due to contamination in the `vote_history` column. eg. `  "\"[\\\"[{\\\\\\\"direction\\\\\\\":\\\\\\\"up\\\\\\\",\\\\\\\"action\\\\\\\":\\\\\\\"create\\\\\\\",\\\\\\\"user_id\\\\\\\":51,\\\\\\\"created_at\\\\\\\":\\\\\\\"2018-11-02T14:21:49.785+00:00\\\\\\\"}]\\\",{\\\"direction\\\":\\\"up\\\",\\\"action\\\":\\\"create\\\",\\\"user_id\\\":61,\\\"created_at\\\":\\\"2018-11-15T18:49:43.875+00:00\\\"}]\"",
`. See post by [Jay](https://meta.discourse.org/t/question-answer-plugin/56032/301?u=nat)

For folks who wish to have that compatibility, we will be happy to accept community help for a rake task which can migrate the data safely.

https://meta.discourse.org/t/plugin-causing-errors-during-rebuild/241110