### PR TITLE
DEV: Fix JS tests to use default site settings

### DIFF
--- a/test/javascripts/acceptance/composer-test.js
+++ b/test/javascripts/acceptance/composer-test.js
@@ -33,6 +33,9 @@ acceptance("Discourse Question Answer - composer", function (needs) {
   test("Creating new topic with Q&A format", async function (assert) {
     await visit("/");
     await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
 
     const composerActions = selectKit(".composer-actions");
     await composerActions.expand();


### PR DESCRIPTION
In preparation for core PR https://github.com/discourse/discourse/pull/18413 which changes JS to load default yml site settings, the main one needing changes is that now the
allow_uncategorized_topics setting is false
by default, which requires setting the category
in the composer before using it.