### PR TITLE
FIX: adjust QA answers header sorts in RTL mode

### DIFF
--- a/assets/stylesheets/common/question-answer.scss
+++ b/assets/stylesheets/common/question-answer.scss
@@ -61,6 +61,25 @@
   }
 }
 
+.rtl .qa-answers-header {
+  .qa-answers-headers-sort {
+    margin-left: unset;
+    margin-right: auto;
+
+    .btn {
+      + .btn {
+        margin-left: 0em;
+        margin-right: 0.3em;
+      }
+
+      &:first-of-type {
+        margin-left: 0em;
+        margin-right: 0.5em;
+      }
+    }
+  }
+}
+
 .qa-comments {
   width: 100%;
   padding-top: 5px;


### PR DESCRIPTION
The commit contains a fix to the location of the answer header sorts buttons in RTL mode. In the image below you can see the change:
- On the top, you can see the current status - the location of the buttons is on the right (which is wrong).
- On the bottom, you can see the fix - the location of the buttons is on the left (which is correct).

![image](https://user-images.githubusercontent.com/35470921/195962251-c9eee62f-454a-4408-84fe-49cf31210162.png)

Steps to reproduce the issue:
- Setup a new and clean Discourse instance.
- In settings, under "default locale" choose some RTL language (for example Hebrew).
- Create a new QA post with one answer and check the sorting buttons.