### PR TITLE
DEV: Empty prettier as per skeleton

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,1 @@
-{
-  "extends": "eslint-config-discourse"
-}
+{}


### PR DESCRIPTION
Plugin skeleton indicates an empty prettier. https://github.com/discourse/discourse-plugin-skeleton/blob/main/.prettierrc